### PR TITLE
Add support for 3-way parity queries.

### DIFF
--- a/src/cplex.ml
+++ b/src/cplex.ml
@@ -39,6 +39,26 @@ let norm_query q = match q with
     let correction_factor = (not_int_of_bool l1s + not_int_of_bool l2s + not_int_of_bool l3s) in
     (ls l1s, l1i, ls l2s, l2i, ls l3s, l3i, 1, -3+correction_factor)
 
+(****************************** PARITIES *************************************)
+(* Return the sign and number of variables, the query factor and the corrected right side *)
+let norm_query_p q = match q with
+  | BPQuery (l1, l2, l3) ->
+    let (l1s, l1i) = decomp_literal l1 in
+    let (l2s, l2i) = decomp_literal l2 in
+    let (l3s, l3i) = decomp_literal l3 in
+    let ls = var_sgn true              in
+    let correction_factor = (not_int_of_bool l1s + not_int_of_bool l2s + not_int_of_bool l3s) in
+    (ls l1s, l1i, ls l2s, l2i, ls l3s, l3i, -correction_factor - 1)
+
+  | BNQuery (l1, l2, l3) ->
+    let (l1s, l1i) = decomp_literal l1 in
+    let (l2s, l2i) = decomp_literal l2 in
+    let (l3s, l3i) = decomp_literal l3 in
+    let ls = var_sgn false             in
+    let correction_factor = (not_int_of_bool l1s + not_int_of_bool l2s + not_int_of_bool l3s) in
+    (ls l1s, l1i, ls l2s, l2i, ls l3s, l3i, correction_factor)
+(**************************** END PARITIES ***********************************)
+
 let string_of_sgn b = if b then "+" else "-"
 
 let string_of_query qnum q =
@@ -48,6 +68,15 @@ let string_of_query qnum q =
     (string_of_sgn l2s) l2i
     (string_of_sgn l3s) l3i
     qf qnum rs
+(****************************** PARITIES *************************************)
+let string_of_query_p qnum q =
+  let (l1s, l1i, l2s, l2i, l3s, l3i, rs) = norm_query_p q in
+  sprintf "%s x%d %s x%d %s x%d - 2p%d - q%d = %d"
+    (string_of_sgn l1s) l1i
+    (string_of_sgn l2s) l2i
+    (string_of_sgn l3s) l3i
+    qnum qnum rs
+(**************************** END PARITIES ***********************************)
 
 (* Original version for non-negated literals *)
 
@@ -103,6 +132,16 @@ let print_query out qnum q =
     (string_of_sgn l2s) l2i
     (string_of_sgn l3s) l3i
     qf qnum rs
+
+(****************************** PARITIES *************************************)
+let print_query_p out qnum q =
+  let (l1s, l1i, l2s, l2i, l3s, l3i, rs) = norm_query_p q in
+  fprintf out "%s x%d %s x%d %s x%d - 2p%d - q%d = %d\n"
+    (string_of_sgn l1s) l1i
+    (string_of_sgn l2s) l2i
+    (string_of_sgn l3s) l3i
+    qnum qnum rs
+(**************************** END PARITIES ***********************************)
 
 let print_queries out q = Array.iteri (print_query out) q
 

--- a/src/parity.ml
+++ b/src/parity.ml
@@ -1,0 +1,283 @@
+(* Copyright (c) 2013, The Trustees of the University of Pennsylvania
+   All rights reserved.
+
+   LICENSE: 3-clause BSD style.
+   See the LICENSE file for details on licensing.
+*)
+
+open Attribute
+open Db
+open Printf
+
+(* Queries are 3-way parities, negated or not *)
+
+(* Note entirely happy with the current query representation, it is a
+   little bit cumbersome and precludes code reuse *)
+type int_literal    = LEq of int * int | LNeq of int * int
+
+type int_3_parity = int_literal * int_literal * int_literal
+
+type query          = PQuery of int_3_parity | NQuery of int_3_parity
+
+type bin_literal    = PVar of int | NVar of int
+
+type bin_three_parity = bin_literal * bin_literal * bin_literal
+
+type bin_query = BPQuery of bin_three_parity | BNQuery of bin_three_parity
+
+
+let generate_bliteral n_att =
+  if Random.bool () then
+    PVar (Random.int n_att)
+  else
+    NVar (Random.int n_att)
+
+let generate_bquery n_att =
+  let inner = (generate_bliteral n_att, generate_bliteral n_att, generate_bliteral n_att) in
+  BPQuery inner
+
+let generate_bqueries n_atts n_q =
+  Array.init n_q (fun _ -> generate_bquery n_atts)
+
+(* Note we may end up generating the same twice, althought it is not likely *)
+let generate_literal n db_schema =
+  let att    = Random.int n                      in
+  let ai     = Array.get db_schema att           in
+  let av     = Random.int (ai.att_max + 1)       in
+  if Random.bool () then
+    LEq (att, av)
+  else
+    LNeq (att, av)
+
+let generate_query n db_schema =
+  let inner = (generate_literal n db_schema, generate_literal n db_schema, generate_literal n db_schema) in
+  PQuery inner
+
+let generate_queries db_schema n_q =
+  let n = Array.length db_schema in
+  Array.init n_q (fun _ -> generate_query n db_schema)
+
+(* Naive *)
+(* let generate_lin_att s a = *)
+(*   if s = 1 then *)
+(*     PVar a *)
+(*   else *)
+(*     NVar a *)
+
+(* let generate_lin_query n_att n = *)
+(*   let q1 = n mod (n_att * 2)                         in *)
+(*   let p1 = q1 mod 2                                  in *)
+(*   let n  = n / (n_att * 2)                           in *)
+(*   let q2 = n mod (n_att * 2)                         in *)
+(*   let p2 = q2 mod 2                                  in *)
+(*   let n  = n / (n_att * 2)                           in *)
+(*   let q3 = n mod (n_att * 2)                         in *)
+(*   let p3 = q3 mod 2                                  in *)
+(*   let n  = n / (n_att * 2)                           in *)
+(*   let qs = n mod 2                                   in *)
+(*   let inner = (generate_lin_att p1 (q1 / 2), generate_lin_att p2 (q2 / 2), generate_lin_att p3 (q3 / 2)) in *)
+(*   if qs = 1 then *)
+(*     NQuery inner *)
+(*   else *)
+(*     PQuery inner *)
+
+(* let generate_lin_queries n_atts n_q = *)
+(*   Array.init n_q (generate_lin_query n_atts) *)
+
+(* (\* Note that this only generates the positive queries *\) *)
+(* let generate_all_queries n_atts = *)
+(*   generate_lin_queries n_atts (n_atts * n_atts * n_atts * 2 * 2 * 2) *)
+
+let to_bin_literal att_map lit = match lit with
+  | LEq  (a, v) ->
+    let (a_pos, ne) = Array.get att_map a in
+    (* Little hack to support binary attributes *)
+    if ne = 0 then
+      (if v = 1 then PVar a_pos else NVar a_pos)
+    else
+      PVar (a_pos + v)
+
+  | LNeq (a, v) ->
+    let (a_pos, ne) = Array.get att_map a in
+    (* Little hack to support binary attributes *)
+    if ne = 0 then
+      (if v = 1 then NVar a_pos else PVar a_pos)
+    else
+      NVar (a_pos + v)
+
+let to_bin_query att_map query = match query with
+  | PQuery (l1, l2, l3) ->
+    let bl1 = to_bin_literal att_map l1 in
+    let bl2 = to_bin_literal att_map l2 in
+    let bl3 = to_bin_literal att_map l3 in
+    BPQuery (bl1, bl2, bl3)
+
+  | NQuery (l1, l2, l3) ->
+    let bl1 = to_bin_literal att_map l1 in
+    let bl2 = to_bin_literal att_map l2 in
+    let bl3 = to_bin_literal att_map l3 in
+    BNQuery (bl1, bl2, bl3)
+
+let to_bin_queries att_map qry =
+  Array.map (to_bin_query att_map) qry
+
+let complement_query q = match q with
+  | PQuery tm -> NQuery tm
+  | NQuery tm -> PQuery tm
+
+let complement_bquery q = match q with
+  | BPQuery tm -> BNQuery tm
+  | BNQuery tm -> BPQuery tm
+
+let complement_queries queries =
+  let c_queries = Array.map complement_query queries in
+  Array.append queries c_queries
+
+let complement_bqueries queries =
+  let c_queries = Array.map complement_bquery queries in
+  Array.append queries c_queries
+
+let complement_qcache  qcache =
+  let c_qcache  = Array.map (fun v -> 1.0 -. v) qcache in
+  Array.append qcache c_qcache
+
+(* Get the first half of an array, that is, without the complements *)
+let remove_complements q =
+  let l = Array.length q / 2 in
+  Array.sub q 0 l
+
+let tof_att  b     = if b then 1.0 else 0.0
+let not_att  a     = not a
+let par3_att a b c =
+  (a && b && not c) ||
+  (c && a && not b) ||
+  (b && c && not a) ||
+  not (a || b || c)
+
+let eval_bin_lit (elem : bin_db_row) lit = match lit with
+  (* We must use the .() notation for -unsafe to work *)
+  | PVar n ->          elem.(n)
+  | NVar n -> not_att  elem.(n)
+
+let eval_btm (elem : bin_db_row) (l1, l2, l3) =
+  par3_att (eval_bin_lit elem l1)
+           (eval_bin_lit elem l2)
+           (eval_bin_lit elem l3)
+
+(* let bool_to_float b = if b then 1.0 else 0.0 *)
+
+(* We can improve performance on this *)
+let eval_bin_elem query (elem : bin_db_row) = match query with
+  | BPQuery tm -> tof_att          (eval_btm elem tm)
+  | BNQuery tm -> tof_att (not_att (eval_btm elem tm))
+
+let eval_bin_query (db : bin_db) query =
+  (* let e_arry = Array.map (eval_elem query) db in *)
+  Array.fold_left (fun qry_val -> fun db_e -> qry_val +. (eval_bin_elem query db_e)) 0.0 db
+
+let eval_bin_queries db queries =
+  Array.map (eval_bin_query db) queries
+
+let eval_lit (elem : db_row) lit = match lit with
+  | LEq  (n, e) -> elem.(n) = e
+  | LNeq (n, e) -> elem.(n) <> e
+
+let eval_tm (elem : db_row) (l1, l2, l3) =
+  par3_att (eval_lit elem l1)
+           (eval_lit elem l2)
+           (eval_lit elem l3)
+
+let eval_elem query (elem : db_row) = match query with
+  | PQuery tm -> tof_att          (eval_tm elem tm)
+  | NQuery tm -> tof_att (not_att (eval_tm elem tm))
+
+let eval_query (db : db) query =
+  (* let e_arry = Array.map (eval_elem query) db in *)
+  Array.fold_left (fun qry_val -> fun db_e -> qry_val +. (eval_elem query db_e)) 0.0 db
+
+(* let ev_norm n res = *)
+(*   Array.map (fun r -> (float_of_int r) /. (float_of_int n)) res *)
+
+(* Perform the normalization in place *)
+let ev_norm n res =
+  let n = float_of_int n in
+  Util.mapi_in_place (fun _idx -> fun r -> r /. n) res
+
+let eval_queries_norm verbose db queries =
+  let db_length = Array.length db         in
+  let n_queries = Array.length queries    in
+  let p_time = ref (Unix.gettimeofday ()) in
+
+  ev_norm db_length
+  (* This is the same than eval_queries but with the print
+
+     The performance here is not very good, but indeed in large
+     databases we are having cache trouble for sure *)
+
+    (* (Parmap.array_float_parmapi ~ncores:n_cores (fun idx q -> *)
+    (Parmap.array_parmapi ~ncores:Params.n_cores (fun idx q ->
+    (* (Array.mapi (fun idx -> fun q -> *)
+    let report = 1000 in
+    if verbose && (idx mod report) = 0 then
+      let a_time    = Unix.gettimeofday ()                        in
+      let secs      = (a_time -. !p_time)                         in
+      let q_by_s    = (float_of_int report) /. secs               in
+      let h_r       = (float_of_int (n_queries - idx)) /. (q_by_s *. 3600.0)    in
+      p_time       := a_time;
+      Printf.printf "**** Evaluating query %d at %.2f q/sec. %.2f hours remaning\n%!" idx q_by_s h_r
+    else
+      ();
+    eval_query db q) queries)
+
+let eval_bqueries_norm verbose db queries =
+  let db_length = Array.length db         in
+  let n_queries = Array.length queries    in
+  let p_time = ref (Unix.gettimeofday ()) in
+
+  ev_norm db_length
+  (* This is the same than eval_queries but with the print
+
+     The performance here is not very good, but indeed in large
+     databases we are having cache trouble for sure *)
+
+    (* (Parmap.array_float_parmapi ~ncores:n_cores (fun idx q -> *)
+    (Parmap.array_parmapi ~ncores:Params.n_cores (fun idx q ->
+    (* (Array.mapi (fun idx -> fun q -> *)
+    let report = 1000 in
+    if verbose && (idx mod report) = 0 then
+      let a_time    = Unix.gettimeofday ()                        in
+      let secs      = (a_time -. !p_time)                         in
+      let q_by_s    = (float_of_int report) /. secs               in
+      let h_r       = (float_of_int (n_queries - idx)) /. (q_by_s *. 3600.0)    in
+      p_time       := a_time;
+      Printf.printf "**** Evaluating query %d at %.2f q/sec. %.2f hours remaning\n%!" idx q_by_s h_r
+    else
+      ();
+    eval_bin_query db q) queries)
+
+let string_of_lt l = match l with
+  | PVar n -> sprintf " %3d" n
+  | NVar n -> sprintf "!%3d" n
+
+let string_of_tm (l1, l2, l3) =
+  sprintf "Parity (%s, %s, %s)"
+    (string_of_lt l1)
+    (string_of_lt l2)
+    (string_of_lt l3)
+
+let print_query i q = match q with
+  | BPQuery tm -> printf "%3d: Even %s\n" i (string_of_tm tm)
+  | BNQuery tm -> printf "%3d: Odd  %s\n" i (string_of_tm tm)
+
+let print_bqueries q =
+  Array.iteri print_query q
+
+(*  *)
+(* let test_eval () = *)
+(*   let n_att   = 30                        in *)
+(*   let db      = generate_db n_att 20      in *)
+(*   let queries = generate_queries n_att 10 in *)
+(*   print_db db; *)
+(*   print_queries queries; *)
+(*   eval_queries db queries *)
+

--- a/src/parity.mli
+++ b/src/parity.mli
@@ -1,0 +1,59 @@
+(* Copyright (c) 2013, The Trustees of the University of Pennsylvania
+   All rights reserved.
+
+   LICENSE: 3-clause BSD style.
+   See the LICENSE file for details on licensing.
+*)
+
+open Db
+
+(* We should use modules for this, but anyways... *)
+
+type int_literal    = LEq of int * int | LNeq of int * int
+
+type int_3_parity = int_literal * int_literal * int_literal
+
+type query          = PQuery of int_3_parity | NQuery of int_3_parity
+
+type bin_literal = PVar of int | NVar of int
+
+type bin_three_parity = bin_literal * bin_literal * bin_literal
+
+type bin_query = BPQuery of bin_three_parity | BNQuery of bin_three_parity
+
+val to_bin_queries : att_map -> query array -> bin_query array
+
+val generate_bquery     : int ->        bin_query
+val generate_bqueries   : int -> int -> bin_query array
+
+val generate_query      : int -> db_schema  -> query
+val generate_queries    : db_schema  -> query
+
+(* Only positive queries *)
+val generate_queries   : db_schema -> int -> query array
+
+(* For later *)
+(* val generate_lin_queries : int -> int -> query array *)
+(* val generate_all_queries : int -> query array *)
+
+val complement_query    : query -> query
+val complement_bquery   : bin_query -> bin_query
+
+val complement_queries  : query array -> query array
+val complement_bqueries : bin_query array -> bin_query array
+
+val complement_qcache   : float array -> float array
+
+val remove_complements  : 'a array -> 'a array
+
+val eval_bin_elem       : bin_query -> bin_db_row -> float
+
+val eval_elem           : query -> db_row       -> float
+val eval_query          : db    -> query        -> float
+
+(* val eval_queries      : db    -> query array  -> float array *)
+
+val eval_queries_norm  : bool -> db -> query array -> float array
+val eval_bqueries_norm : bool -> bin_db -> bin_query array -> float array
+
+val print_bqueries : bin_query array -> unit


### PR DESCRIPTION
Looking at the diff, there is really a lot of code duplication. Ideally, we would want to have a way to cleanly add query classes including evaluation and cplex printing.

For linear queries, it should be possible to do the attribute/query generation separately (or maybe based on a parameter, like the number of attributes to take).

Anyways, this should do for now. Beware, I have only compiled the code :)
